### PR TITLE
Change the way RPCHelper accesses the stackTrace in order to get the methodName.

### DIFF
--- a/extension/rsb/com/src/main/java/org/openbase/jul/extension/rsb/com/RPCHelper.java
+++ b/extension/rsb/com/src/main/java/org/openbase/jul/extension/rsb/com/RPCHelper.java
@@ -95,22 +95,22 @@ public class RPCHelper {
     }
 
     public static Future<Object> callRemoteMethod(final RSBRemote remote) throws CouldNotPerformException {
-        return callRemoteMethod(null, remote, Object.class, 3);
+        return internalCallRemoteMethod(null, remote, Object.class);
     }
 
     public static Future<Object> callRemoteMethod(final Object argument, final RSBRemote remote) throws CouldNotPerformException {
-        return callRemoteMethod(argument, remote, Object.class, 3);
+        return internalCallRemoteMethod(argument, remote, Object.class);
     }
 
     public static <RETURN> Future<RETURN> callRemoteMethod(final RSBRemote remote, final Class<? extends RETURN> returnClass) throws CouldNotPerformException {
-        return callRemoteMethod(null, remote, returnClass, 3);
+        return internalCallRemoteMethod(null, remote, returnClass);
     }
 
     public static <RETURN> Future<RETURN> callRemoteMethod(final Object argument, final RSBRemote remote, final Class<? extends RETURN> returnClass) throws CouldNotPerformException {
-        return callRemoteMethod(argument, remote, returnClass, 3);
+        return internalCallRemoteMethod(argument, remote, returnClass);
     }
 
-    private static <RETURN> Future<RETURN> callRemoteMethod(final Object argument, final RSBRemote remote, final Class<? extends RETURN> returnClass, int methodStackDepth) throws CouldNotPerformException {
+    private static <RETURN> Future<RETURN> internalCallRemoteMethod(final Object argument, final RSBRemote remote, final Class<? extends RETURN> returnClass) throws CouldNotPerformException {
 
         String methodName = "?";
         try {
@@ -122,7 +122,12 @@ public class RPCHelper {
             }
 
             try {
-                methodName = stackTrace[methodStackDepth].getMethodName();
+                for (int i = 0; i < stackTrace.length; i++) {
+                    if (stackTrace[i].getMethodName().equals("callRemoteMethod")) {
+                        methodName = stackTrace[i+1].getMethodName();
+                        break;
+                    }
+                }
             } catch (NullPointerException | IndexOutOfBoundsException ex) {
                 throw new CouldNotPerformException("Could not detect method name!");
             }

--- a/extension/rsb/com/src/main/java/org/openbase/jul/extension/rsb/com/RPCHelper.java
+++ b/extension/rsb/com/src/main/java/org/openbase/jul/extension/rsb/com/RPCHelper.java
@@ -44,6 +44,8 @@ import org.openbase.jul.extension.rsb.iface.RSBLocalServer;
 public class RPCHelper {
 
 //    static final Logger logger = LoggerFactory.getLogger(RPCHelper.class);
+    private static final String INTERNAL_CALL_REMOTE_METHOD_NAME = "internalCallRemoteMethod";
+
     public static <I, T extends I> void registerInterface(final Class<I> interfaceClass, final T instance, final RSBLocalServer server) throws CouldNotPerformException {
         for (final Method method : interfaceClass.getMethods()) {
             if (method.getAnnotation(RPCMethod.class) != null) {
@@ -123,8 +125,8 @@ public class RPCHelper {
 
             try {
                 for (int i = 0; i < stackTrace.length; i++) {
-                    if (stackTrace[i].getMethodName().equals("callRemoteMethod")) {
-                        methodName = stackTrace[i+1].getMethodName();
+                    if (stackTrace[i].getMethodName().equals(INTERNAL_CALL_REMOTE_METHOD_NAME)) {
+                        methodName = stackTrace[i+2].getMethodName();
                         break;
                     }
                 }


### PR DESCRIPTION
This fixes an issue on Android