### PR TITLE
[65] fix client already disconnected failure.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+### :scroll: Description
+
+Changes proposed in this pull request:
+* ...
+
+### :hammer: Breaking Changes
+
+* Report any api changes
+
+### :white_check_mark: Checklist:
+
+- [ ] Created tests which fail without the change (if possible)
+- [ ] Extended the documentation (if necessary)
+
+### :camera_flash: Screenshots
+
+Screenshots to review the UX/UI Design:

--- a/communication/mqtt/src/main/java/org/openbase/jul/communication/mqtt/SharedMqttClient.kt
+++ b/communication/mqtt/src/main/java/org/openbase/jul/communication/mqtt/SharedMqttClient.kt
@@ -2,20 +2,14 @@ package org.openbase.jul.communication.mqtt
 
 import com.hivemq.client.mqtt.MqttClient
 import com.hivemq.client.mqtt.MqttGlobalPublishFilter
+import com.hivemq.client.mqtt.datatypes.MqttTopicFilter
 import com.hivemq.client.mqtt.mqtt5.Mqtt5AsyncClient
 import com.hivemq.client.mqtt.mqtt5.Mqtt5BlockingClient
-import com.hivemq.client.mqtt.mqtt5.Mqtt5ClientConfig
 import com.hivemq.client.mqtt.mqtt5.Mqtt5RxClient
 import com.hivemq.client.mqtt.mqtt5.message.connect.Mqtt5Connect
-import com.hivemq.client.mqtt.mqtt5.message.connect.Mqtt5ConnectBuilder
-import com.hivemq.client.mqtt.mqtt5.message.connect.connack.Mqtt5ConnAck
 import com.hivemq.client.mqtt.mqtt5.message.disconnect.Mqtt5Disconnect
-import com.hivemq.client.mqtt.mqtt5.message.disconnect.Mqtt5DisconnectBuilder
 import com.hivemq.client.mqtt.mqtt5.message.publish.Mqtt5Publish
-import com.hivemq.client.mqtt.mqtt5.message.publish.Mqtt5PublishBuilder
-import com.hivemq.client.mqtt.mqtt5.message.publish.Mqtt5PublishResult
 import com.hivemq.client.mqtt.mqtt5.message.subscribe.Mqtt5Subscribe
-import com.hivemq.client.mqtt.mqtt5.message.subscribe.suback.Mqtt5SubAck
 import com.hivemq.client.mqtt.mqtt5.message.unsubscribe.Mqtt5Unsubscribe
 import com.hivemq.client.mqtt.mqtt5.message.unsubscribe.Mqtt5UnsubscribeBuilder
 import com.hivemq.client.mqtt.mqtt5.message.unsubscribe.unsuback.Mqtt5UnsubAck
@@ -39,181 +33,153 @@ object SharedMqttClient : Shutdownable {
     }
 
     @Synchronized
-    fun get(communicatorConfig: CommunicatorConfig): Mqtt5AsyncClient {
-        if (!sharedClients.containsKey(communicatorConfig)) {
-            val client = MqttClient.builder()
+    fun get(
+        communicatorConfig: CommunicatorConfig
+    ) = sharedClients.getOrPut(communicatorConfig) {
+            MqttClient.builder()
                 .identifier(UUID.randomUUID().toString())
                 .serverHost(communicatorConfig.hostname)
                 .serverPort(communicatorConfig.port)
                 .useMqttVersion5()
                 .automaticReconnectWithDefaultConfig()
                 .buildAsync()
-            val wrappedClient = Mqtt5ClientWrapper(client)
-            wrappedClient.connect()
-            sharedClients[communicatorConfig] = wrappedClient
+                .let { Mqtt5ClientWrapper(it) }
+                .also { it.connect() }
         }
 
-        return sharedClients[communicatorConfig]!!
-    }
-
     @Synchronized
-    fun waitForShutdown() {
-        sharedClients.values.forEach { client ->
-            client.disconnect().get()
-        }
-        sharedClients.clear()
-    }
-
-    @Synchronized
-    override fun shutdown() {
+    fun waitForShutdown() =
         sharedClients.values
-            .onEach{ it.disconnect() }
-            .also { sharedClients.clear() }
-    }
+            .filter { (it as Mqtt5ClientWrapper).isConnected() }
+            .map { it.disconnect() }
+            .map { it.get() }
+            .run { sharedClients.clear() }
+
+    @Synchronized
+    override fun shutdown(): Unit =
+        sharedClients.values
+            .filter { (it as Mqtt5ClientWrapper).isConnected() }
+            .onEach { it.disconnect() }
+            .run { sharedClients.clear() }
 
     /**
      * Wrapper around an MQTT client to enable sharing.
      * It tracks the amount of subscriptions to a topic and only unsubscribes if
      * unsubscribe is called on the last client.
      */
-    internal class Mqtt5ClientWrapper(private val internalClient: Mqtt5AsyncClient) : Mqtt5AsyncClient {
+    internal class Mqtt5ClientWrapper(
+        private val internalClient: Mqtt5AsyncClient
+    ) : Mqtt5AsyncClient {
 
         /**
          * Map topics to the number of times subscribed to.
          */
         private val subscriptionsCounterMap: MutableMap<String, Int> = mutableMapOf()
 
-        private fun increaseTopicCounter(topic: String) {
-            subscriptionsCounterMap[topic] = subscriptionsCounterMap.getOrPut(topic) { 0 } + 1
-        }
+        fun isConnected() = internalClient.config.state.isConnected
 
-        private fun decreaseTopicCounter(topic: String): Boolean {
-            if (subscriptionsCounterMap[topic] == null || subscriptionsCounterMap[topic] == 0) {
-                return false
+        @Synchronized
+        private fun increaseTopicCounter(topic: MqttTopicFilter): Unit = topic
+            .toString()
+            .also { subscriptionsCounterMap[it] = subscriptionsCounterMap.getOrPut(it) { 0 } + 1 }
+            .let { }
+
+        @Synchronized
+        private fun decreaseTopicCounter(topicFilter: MqttTopicFilter): Boolean = topicFilter
+            .toString()
+            .let { topic ->
+                subscriptionsCounterMap[topic]
+                    .let { it == null || it == 0 }
+                    .also { if (it) return false }
+
+                subscriptionsCounterMap[topic] = subscriptionsCounterMap[topic]!! - 1
+                subscriptionsCounterMap[topic] == 0
             }
-            subscriptionsCounterMap[topic] = subscriptionsCounterMap[topic]!! - 1
-            return subscriptionsCounterMap[topic] == 0
-        }
 
-        override fun getConfig(): Mqtt5ClientConfig {
-            return internalClient.config
-        }
+        override fun getConfig() = internalClient.config
 
-        override fun toRx(): Mqtt5RxClient {
-            return internalClient.toRx()
-        }
+        override fun toRx(): Mqtt5RxClient = internalClient.toRx()
 
-        override fun toBlocking(): Mqtt5BlockingClient {
-            return internalClient.toBlocking()
-        }
+        override fun toBlocking(): Mqtt5BlockingClient = internalClient.toBlocking()
 
-        override fun connect(): CompletableFuture<Mqtt5ConnAck> {
-            return internalClient.connect()
-        }
+        override fun connect() = internalClient.connect()
 
-        override fun connect(p0: Mqtt5Connect): CompletableFuture<Mqtt5ConnAck> {
-            return internalClient.connect(p0)
-        }
+        override fun connect(p0: Mqtt5Connect) = internalClient.connect(p0)
 
-        override fun connectWith(): Mqtt5ConnectBuilder.Send<CompletableFuture<Mqtt5ConnAck>> {
-            return internalClient.connectWith()
-        }
+        override fun connectWith() = internalClient.connectWith()
 
-        override fun subscribe(p0: Mqtt5Subscribe): CompletableFuture<Mqtt5SubAck> {
-            increaseTopicCounter(p0.subscriptions[0].topicFilter.toString())
-            return internalClient.subscribe(p0)
-        }
+        override fun subscribe(
+            p0: Mqtt5Subscribe
+        ) = p0.subscriptions
+            .map { increaseTopicCounter(it.topicFilter) }
+            .let { internalClient.subscribe(p0) }
 
-        override fun subscribe(p0: Mqtt5Subscribe, p1: Consumer<Mqtt5Publish>): CompletableFuture<Mqtt5SubAck> {
-            increaseTopicCounter(p0.subscriptions[0].topicFilter.toString())
-            return internalClient.subscribe(p0, p1)
-        }
+        override fun subscribe(
+            p0: Mqtt5Subscribe,
+            p1: Consumer<Mqtt5Publish>
+        ) = p0.subscriptions
+            .map { increaseTopicCounter(it.topicFilter) }
+            .let { internalClient.subscribe(p0, p1) }
 
         override fun subscribe(
             p0: Mqtt5Subscribe,
             p1: Consumer<Mqtt5Publish>,
             p2: Executor
-        ): CompletableFuture<Mqtt5SubAck> {
-            increaseTopicCounter(p0.subscriptions[0].topicFilter.toString())
-            return internalClient.subscribe(p0, p1, p2)
-        }
+        ) = p0.subscriptions
+            .map { increaseTopicCounter(it.topicFilter) }
+            .let { internalClient.subscribe(p0, p1, p2) }
 
         override fun subscribe(
             p0: Mqtt5Subscribe,
             p1: Consumer<Mqtt5Publish>,
             p2: Boolean
-        ): CompletableFuture<Mqtt5SubAck> {
-            increaseTopicCounter(p0.subscriptions[0].topicFilter.toString())
-            return internalClient.subscribe(p0, p1, p2)
-        }
+        ) = p0.subscriptions
+            .map { increaseTopicCounter(it.topicFilter) }
+            .let { internalClient.subscribe(p0, p1, p2) }
 
         override fun subscribe(
             p0: Mqtt5Subscribe,
             p1: Consumer<Mqtt5Publish>,
             p2: Executor,
             p3: Boolean
-        ): CompletableFuture<Mqtt5SubAck> {
-            increaseTopicCounter(p0.subscriptions[0].topicFilter.toString())
-            return internalClient.subscribe(p0, p1, p2, p3)
-        }
+        ) = p0.subscriptions
+            .map { increaseTopicCounter(it.topicFilter) }
+            .let { internalClient.subscribe(p0, p1, p2, p3) }
 
-        override fun subscribeWith(): Mqtt5AsyncClient.Mqtt5SubscribeAndCallbackBuilder.Start {
-            TODO("Not yet implemented")
-        }
+        override fun subscribeWith() = throw NotImplementedError("This method is not supported by this implementation.")
 
-        override fun publishes(p0: MqttGlobalPublishFilter, p1: Consumer<Mqtt5Publish>) {
-            TODO("Not yet implemented")
-        }
+        override fun publishes(p0: MqttGlobalPublishFilter, p1: Consumer<Mqtt5Publish>) =
+            internalClient.publishes(p0, p1)
 
-        override fun publishes(p0: MqttGlobalPublishFilter, p1: Consumer<Mqtt5Publish>, p2: Executor) {
-            TODO("Not yet implemented")
-        }
+        override fun publishes(p0: MqttGlobalPublishFilter, p1: Consumer<Mqtt5Publish>, p2: Executor) =
+            internalClient.publishes(p0, p1, p2)
 
-        override fun publishes(p0: MqttGlobalPublishFilter, p1: Consumer<Mqtt5Publish>, p2: Boolean) {
-            TODO("Not yet implemented")
-        }
+        override fun publishes(p0: MqttGlobalPublishFilter, p1: Consumer<Mqtt5Publish>, p2: Boolean) =
+            internalClient.publishes(p0, p1, p2)
 
-        override fun publishes(p0: MqttGlobalPublishFilter, p1: Consumer<Mqtt5Publish>, p2: Executor, p3: Boolean) {
-            TODO("Not yet implemented")
-        }
+        override fun publishes(p0: MqttGlobalPublishFilter, p1: Consumer<Mqtt5Publish>, p2: Executor, p3: Boolean) =
+            internalClient.publishes(p0, p1, p2, p3)
 
-        override fun unsubscribe(p0: Mqtt5Unsubscribe): CompletableFuture<Mqtt5UnsubAck> {
-            if (decreaseTopicCounter(p0.topicFilters[0].toString())) {
-                return internalClient.unsubscribe(p0)
-            }
+        override fun unsubscribe(
+            p0: Mqtt5Unsubscribe
+        ): CompletableFuture<Mqtt5UnsubAck> = p0.topicFilters
+            .filter { decreaseTopicCounter(it) }
+            .let {  Mqtt5Unsubscribe.builder().addTopicFilters(it).build() }
+            .let { internalClient.unsubscribe(it) }
 
-            val future = CompletableFuture<Mqtt5UnsubAck>()
-            future.complete(null)
-            return future
-        }
+        override fun unsubscribeWith(): Mqtt5UnsubscribeBuilder.Send.Start<CompletableFuture<Mqtt5UnsubAck>> =
+            throw NotImplementedError("This method is not supported by this implementation.")
 
-        override fun unsubscribeWith(): Mqtt5UnsubscribeBuilder.Send.Start<CompletableFuture<Mqtt5UnsubAck>> {
-            TODO("Not yet implemented")
-        }
+        override fun publish(p0: Mqtt5Publish) = internalClient.publish(p0)
 
-        override fun publish(p0: Mqtt5Publish): CompletableFuture<Mqtt5PublishResult> {
-            return internalClient.publish(p0)
-        }
+        override fun publishWith() = internalClient.publishWith()
 
-        override fun publishWith(): Mqtt5PublishBuilder.Send<CompletableFuture<Mqtt5PublishResult>> {
-            TODO("Not yet implemented")
-        }
+        override fun reauth() = internalClient.reauth()
 
-        override fun reauth(): CompletableFuture<Void> {
-            return internalClient.reauth()
-        }
+        override fun disconnect() = internalClient.disconnect()
 
-        override fun disconnect(): CompletableFuture<Void> {
-            return internalClient.disconnect()
-        }
+        override fun disconnect(p0: Mqtt5Disconnect) = internalClient.disconnect(p0)
 
-        override fun disconnect(p0: Mqtt5Disconnect): CompletableFuture<Void> {
-            return internalClient.disconnect(p0)
-        }
-
-        override fun disconnectWith(): Mqtt5DisconnectBuilder.Send<CompletableFuture<Void>> {
-            TODO("Not yet implemented")
-        }
-
+        override fun disconnectWith() = internalClient.disconnectWith()
     }
 }

--- a/communication/mqtt/src/test/java/org/openbase/jul/communication/mqtt/SharedMqttClientTest.kt
+++ b/communication/mqtt/src/test/java/org/openbase/jul/communication/mqtt/SharedMqttClientTest.kt
@@ -1,0 +1,19 @@
+package org.openbase.jul.communication.mqtt
+
+import org.junit.jupiter.api.Test
+
+import org.openbase.jul.communication.config.CommunicatorConfig
+
+internal class SharedMqttClientTest {
+
+    @Test
+    fun `shutdown should be work as expected`() {
+        val config = CommunicatorConfig(IntegrationTest.broker.host, IntegrationTest.broker.firstMappedPort)
+        val client = SharedMqttClient
+        client.get(config).apply {
+            disconnect()
+        }
+        client.waitForShutdown()
+        client.shutdown()
+    }
+}


### PR DESCRIPTION
### :scroll: Description

Changes proposed in this pull request:
* fix the exception listed below that is throw in case `SharedMqttClient.waitForShutdown`or `SharedMqttClient.shutdown` is called on an already disconnected Client.
  * By filtering clients topics that are not connected.
* Make sure that `increaseTopicCounter`  and `decreaseTopicCounter` is applied for all configured topics and not only for the first one.
* Refactor `SharedMqttClient` to improve kotlin code style.
* Introduce a test to make sure that the issue does not appear again.
* Introduces a PR template for JUL

```
java.util.concurrent.ExecutionException: com.hivemq.client.mqtt.exceptions.MqttClientStateException: MQTT client is not connected.

	at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:395)
	at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:1999)
	at org.openbase.jul.communication.mqtt.SharedMqttClient.waitForShutdown(SharedMqttClient.kt:55)
	at org.openbase.jul.communication.mqtt.SharedMqttClientTest.shutdown should be work as expected(SharedMqttClientTest.kt:16)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:686)
	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:149)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:140)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:84)
	at org.junit.jupiter.engine.execution.ExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(ExecutableInvoker.java:115)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:104)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:98)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$6(TestMethodTestDescriptor.java:212)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:208)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:137)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:71)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:135)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1540)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1540)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:32)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:51)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:248)
	at org.junit.platform.launcher.core.DefaultLauncher.lambda$execute$5(DefaultLauncher.java:211)
	at org.junit.platform.launcher.core.DefaultLauncher.withInterceptedStreams(DefaultLauncher.java:226)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:199)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:132)
	at com.intellij.junit5.JUnit5IdeaTestRunner.startRunnerWithArgs(JUnit5IdeaTestRunner.java:71)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater$1.execute(IdeaTestRunner.java:38)
	at com.intellij.rt.execution.junit.TestsRepeater.repeat(TestsRepeater.java:11)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:35)
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:235)
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:54)
Caused by: com.hivemq.client.mqtt.exceptions.MqttClientStateException: MQTT client is not connected.
```

### :hammer: Breaking Changes

* Report any api changes

### :white_check_mark: Checklist:

- [x] Created tests which fail without the change (if possible)