### PR TITLE
Bugfix/bco#77 review protobuf merge from usage to avoid list entry dublication

### DIFF
--- a/module/extension/protobuf/src/main/java/org/openbase/jul/extension/protobuf/ProtoBufBuilderProcessor.kt
+++ b/module/extension/protobuf/src/main/java/org/openbase/jul/extension/protobuf/ProtoBufBuilderProcessor.kt
@@ -426,5 +426,5 @@ object ProtoBufBuilderProcessor {
         }
     }
 
-
+    fun Message.Builder.mergeFromWithoutRepeatedFields(message: Message): Message.Builder = TODO()
 }

--- a/module/extension/protobuf/src/main/java/org/openbase/jul/extension/protobuf/ProtoBufBuilderProcessor.kt
+++ b/module/extension/protobuf/src/main/java/org/openbase/jul/extension/protobuf/ProtoBufBuilderProcessor.kt
@@ -426,5 +426,11 @@ object ProtoBufBuilderProcessor {
         }
     }
 
+    fun mergeFromWithoutRepeatedFields(message: Message): Message.Builder = TODO()
+
+    /**
+     * This method clears all repeated fields from the given message before the `mergeFrom` is performed.
+     * This functionality can be useful, since `mergeFrom` would always dublicate
+     */
     fun Message.Builder.mergeFromWithoutRepeatedFields(message: Message): Message.Builder = TODO()
 }

--- a/module/extension/protobuf/src/main/java/org/openbase/jul/extension/protobuf/ProtoBufBuilderProcessor.kt
+++ b/module/extension/protobuf/src/main/java/org/openbase/jul/extension/protobuf/ProtoBufBuilderProcessor.kt
@@ -426,11 +426,13 @@ object ProtoBufBuilderProcessor {
         }
     }
 
-    fun mergeFromWithoutRepeatedFields(message: Message): Message.Builder = TODO()
-
     /**
      * This method clears all repeated fields from the given message before the `mergeFrom` is performed.
-     * This functionality can be useful, since `mergeFrom` would always dublicate
+     * This functionality can be useful, since `mergeFrom` would always duplicate all repeated fields
+     * which can be avoided by using this function instead.
+     * @param message the message to merge from.
      */
-    fun Message.Builder.mergeFromWithoutRepeatedFields(message: Message): Message.Builder = TODO()
+    @JvmStatic
+    fun Message.Builder.mergeFromWithoutRepeatedFields(message: Message): Message.Builder =
+        mergeFromWithoutRepeatedFields(message)
 }

--- a/module/extension/protobuf/src/main/java/org/openbase/jul/extension/protobuf/ProtoBufBuilderProcessor.kt
+++ b/module/extension/protobuf/src/main/java/org/openbase/jul/extension/protobuf/ProtoBufBuilderProcessor.kt
@@ -433,22 +433,34 @@ object ProtoBufBuilderProcessor {
      * @param message the message to merge from.
      */
     @JvmStatic
-    fun Message.Builder.mergeFromWithoutRepeatedFields(message: Message): Message.Builder =
+    fun <MB : Message.Builder> MB.mergeFromWithoutRepeatedFields(builder: Message.Builder): MB =
+        // we should not modify the passed builder, so we need to transform it into a message first.
+        mergeFromWithoutRepeatedFields(builder.build())
+
+    /**
+     * This method clears all repeated fields from the given message before the `mergeFrom` is performed.
+     * This functionality can be useful, since `mergeFrom` would always duplicate all repeated fields
+     * which can be avoided by using this function instead.
+     * @param message the message to merge from.
+     */
+    @JvmStatic
+    fun <MB : Message.Builder> MB.mergeFromWithoutRepeatedFields(message: Message): MB =
         message.toBuilder()
             .let { messageBuilder -> messageBuilder.clearRepeatedFields() }
-            .let { messageBuilder -> mergeFrom(messageBuilder.build()) }
-
+            .let { messageBuilder -> mergeFrom(messageBuilder.build()) as MB }
 
     /**
      * This method recursively clears all repeated fields from the builder instance.
      */
     @JvmStatic
-    fun Message.Builder.clearRepeatedFields(): Message.Builder = also {
+    fun <MB : Message.Builder> MB.clearRepeatedFields(): MB = also { builder ->
         allFields.keys.forEach { descriptor ->
-            descriptor.takeIf { it.isRepeated }?.also { clearField(it) }
-            descriptor.takeIf { it.javaType == Descriptors.FieldDescriptor.JavaType.MESSAGE } ?.also {
-                getFieldBuilder(it).clearRepeatedFields()
-            }
+            descriptor
+                .takeIf { it.isRepeated }
+                ?.also {clearField(it) ; return@forEach }
+            descriptor
+                .takeIf { it.javaType == Descriptors.FieldDescriptor.JavaType.MESSAGE }
+                ?.also { builder.getFieldBuilder(it).clearRepeatedFields() }
         }
     }
 }

--- a/module/extension/protobuf/src/main/java/org/openbase/jul/extension/protobuf/ProtoBufBuilderProcessor.kt
+++ b/module/extension/protobuf/src/main/java/org/openbase/jul/extension/protobuf/ProtoBufBuilderProcessor.kt
@@ -434,5 +434,21 @@ object ProtoBufBuilderProcessor {
      */
     @JvmStatic
     fun Message.Builder.mergeFromWithoutRepeatedFields(message: Message): Message.Builder =
-        mergeFromWithoutRepeatedFields(message)
+        message.toBuilder()
+            .let { messageBuilder -> messageBuilder.clearRepeatedFields() }
+            .let { messageBuilder -> mergeFrom(messageBuilder.build()) }
+
+
+    /**
+     * This method recursively clears all repeated fields from the builder instance.
+     */
+    @JvmStatic
+    fun Message.Builder.clearRepeatedFields(): Message.Builder = also {
+        allFields.keys.forEach { descriptor ->
+            descriptor.takeIf { it.isRepeated }?.also { clearField(it) }
+            descriptor.takeIf { it.javaType == Descriptors.FieldDescriptor.JavaType.MESSAGE } ?.also {
+                getFieldBuilder(it).clearRepeatedFields()
+            }
+        }
+    }
 }

--- a/module/extension/protobuf/src/test/java/org/openbase/jul/extension/protobuf/ProtoBufBuilderProcessorTest.kt
+++ b/module/extension/protobuf/src/test/java/org/openbase/jul/extension/protobuf/ProtoBufBuilderProcessorTest.kt
@@ -1,0 +1,65 @@
+package org.openbase.jul.extension.protobuf
+
+import io.kotest.matchers.comparables.shouldBeEqualComparingTo
+import io.kotest.matchers.ints.shouldBeExactly
+import org.junit.jupiter.api.Test
+
+import org.openbase.jul.extension.protobuf.ProtoBufBuilderProcessor.clearRepeatedFields
+import org.openbase.jul.extension.protobuf.ProtoBufBuilderProcessor.mergeFromWithoutRepeatedFields
+import org.openbase.type.domotic.action.ActionDescriptionType.ActionDescription
+import org.openbase.type.language.MultiLanguageTextType.MultiLanguageText
+
+internal class ProtoBufBuilderProcessorTest {
+
+    companion object {
+        private const val DE = "de"
+        private const val EN = "en"
+        private const val ES = "es"
+        private const val EN_DOG = "dog"
+        private const val DE_DOG = "hund"
+        private const val ES_DOG = "perro"
+    }
+
+    @Test
+    fun clearRepeatedFields() {
+        ActionDescription.newBuilder().also {
+            it.descriptionBuilder.addAllEntry(
+                mutableListOf(
+                    MultiLanguageText.MapFieldEntry.newBuilder().setKey(DE).setValue(DE_DOG).build(),
+                    MultiLanguageText.MapFieldEntry.newBuilder().setKey(EN).setValue(EN_DOG).build(),
+                    MultiLanguageText.MapFieldEntry.newBuilder().setKey(ES).setValue(ES_DOG).build(),
+                )
+            ).build()
+        }.clearRepeatedFields().apply {
+            descriptionBuilder.entryCount shouldBeExactly 0
+        }
+    }
+
+    @Test
+    fun mergeFromWithoutRepeatedFields() {
+        val originBuilder = ActionDescription.newBuilder().also {
+            it.descriptionBuilder.addAllEntry(
+                mutableListOf(
+                    MultiLanguageText.MapFieldEntry.newBuilder().setKey(DE).setValue(DE_DOG).build(),
+                    MultiLanguageText.MapFieldEntry.newBuilder().setKey(EN).setValue(EN_DOG).build(),
+                )
+            ).build()
+        }
+
+        val builderToMerge = ActionDescription.newBuilder().also {
+            it.descriptionBuilder.addAllEntry(
+                mutableListOf(
+                    MultiLanguageText.MapFieldEntry.newBuilder().setKey(ES).setValue(ES_DOG).build(),
+                )
+            ).build()
+        }
+
+        originBuilder.mergeFromWithoutRepeatedFields(builderToMerge).apply {
+            descriptionBuilder.entryCount shouldBeExactly 2
+            descriptionBuilder.entryBuilderList[0].key shouldBeEqualComparingTo DE
+            descriptionBuilder.entryBuilderList[0].value shouldBeEqualComparingTo DE_DOG
+            descriptionBuilder.entryBuilderList[1].key shouldBeEqualComparingTo EN
+            descriptionBuilder.entryBuilderList[1].value shouldBeEqualComparingTo EN_DOG
+        }
+    }
+}

--- a/module/extension/protobuf/src/test/java/org/openbase/jul/extension/protobuf/ProtoBufBuilderProcessorTest.kt
+++ b/module/extension/protobuf/src/test/java/org/openbase/jul/extension/protobuf/ProtoBufBuilderProcessorTest.kt
@@ -21,7 +21,7 @@ internal class ProtoBufBuilderProcessorTest {
     }
 
     @Test
-    fun clearRepeatedFields() {
+    fun `should remove repeated fields` () {
         ActionDescription.newBuilder().also {
             it.descriptionBuilder.addAllEntry(
                 mutableListOf(
@@ -36,7 +36,7 @@ internal class ProtoBufBuilderProcessorTest {
     }
 
     @Test
-    fun mergeFromWithoutRepeatedFields() {
+    fun `should only merge from non-repeated fields`() {
         val originBuilder = ActionDescription.newBuilder().also {
             it.descriptionBuilder.addAllEntry(
                 mutableListOf(


### PR DESCRIPTION
### :scroll: Description

Changes proposed in this pull request:
* Introduce `mergeFromWithoutRepeatedFields` extension function of `Message.Builder`
* Introduce `clearRepeatedFields` extension function of `Message.Builder`
* Implement Test for  `mergeFromWithoutRepeatedFields`
* Implement Test for  `clearRepeatedFields`

### :white_check_mark: Checklist:

- [x] Created tests which fail without the change.
