### PR TITLE
Feature/#86 parallel rpcs

### DIFF
--- a/module/communication/controller/src/test/java/org/openbase/jul/communication/controller/AbstractControllerServerTest.java
+++ b/module/communication/controller/src/test/java/org/openbase/jul/communication/controller/AbstractControllerServerTest.java
@@ -10,19 +10,18 @@ package org.openbase.jul.communication.controller;
  * it under the terms of the GNU Lesser General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Lesser Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Lesser Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
  * #L%
  */
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.openbase.jul.communication.iface.RPCServer;
@@ -32,6 +31,8 @@ import org.openbase.jul.exception.InstantiationException;
 import org.openbase.jul.exception.StackTracePrinter;
 import org.openbase.jul.exception.printer.ExceptionPrinter;
 import org.openbase.jul.exception.printer.LogLevel;
+import org.openbase.jul.extension.protobuf.BuilderSyncSetup;
+import org.openbase.jul.extension.protobuf.ClosableDataBuilder;
 import org.openbase.jul.schedule.GlobalCachedExecutorService;
 import org.openbase.jul.schedule.Stopwatch;
 import org.openbase.jul.schedule.SyncObject;
@@ -151,7 +152,7 @@ public class AbstractControllerServerTest extends MqttIntegrationTest {
     /**
      * Test if a RemoteService will reconnect when the communication service
      * restarts.
-     *
+     * <p>
      * This test validates, that at least 10 re-connection cycles can be repeated
      * within a timeout of 5 seconds.
      */
@@ -393,6 +394,50 @@ public class AbstractControllerServerTest extends MqttIntegrationTest {
             fail("No exception occurred.");
         } catch (CouldNotPerformException ex) {
             // this should happen
+        }
+    }
+
+    /**
+     * Test if methods of the controller can be called in parallel by blocking one call and
+     * then pinging while the method is blocked.
+     *
+     * @throws Exception if any error occurs
+     */
+    @Timeout(5)
+    @Test
+    public void testParallelMethodCall() throws Exception {
+        final String scope = "/test/parallel";
+
+        // create and activate controller
+        communicationService = new AbstractControllerServerImpl(UnitRegistryData.getDefaultInstance().toBuilder());
+        communicationService.init(scope);
+        communicationService.activate();
+
+        // create and activate remote
+        AbstractRemoteClient<UnitRegistryData> remoteService = new AbstractRemoteClientImpl();
+        remoteService.init(scope);
+        remoteService.activate();
+        // wait for synchronization
+        remoteService.requestData().get();
+
+        // acquire the data lock, this means that all requestStatus calls are blocked
+        try (ClosableDataBuilder<UnitRegistryData.Builder> ignored = communicationService.getDataBuilderInterruptible(scope, BuilderSyncSetup.NotificationStrategy.SKIP)) {
+
+
+            // initiate request data call which is blocked
+            final Future<UnitRegistryData> dataFuture = remoteService.requestData();
+
+            // verify that pinging is still possible
+            remoteService.ping().get();
+
+            // verify that the data request is really blocked
+            TimeoutException timeoutException = null;
+            try {
+                dataFuture.get(500, TimeUnit.MILLISECONDS);
+            } catch (TimeoutException ex) {
+                timeoutException = ex;
+            }
+            assertNotNull(timeoutException, "Request data could be called even though the test thread holds the data lock!");
         }
     }
 

--- a/module/communication/controller/src/test/java/org/openbase/jul/communication/controller/AbstractControllerServerTest.java
+++ b/module/communication/controller/src/test/java/org/openbase/jul/communication/controller/AbstractControllerServerTest.java
@@ -422,8 +422,6 @@ public class AbstractControllerServerTest extends MqttIntegrationTest {
 
         // acquire the data lock, this means that all requestStatus calls are blocked
         try (ClosableDataBuilder<UnitRegistryData.Builder> ignored = communicationService.getDataBuilderInterruptible(scope, BuilderSyncSetup.NotificationStrategy.SKIP)) {
-
-
             // initiate request data call which is blocked
             final Future<UnitRegistryData> dataFuture = remoteService.requestData();
 

--- a/module/communication/controller/src/test/java/org/openbase/jul/communication/controller/AbstractControllerServerTest.java
+++ b/module/communication/controller/src/test/java/org/openbase/jul/communication/controller/AbstractControllerServerTest.java
@@ -24,6 +24,7 @@ package org.openbase.jul.communication.controller;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.function.Executable;
 import org.openbase.jul.communication.iface.RPCServer;
 import org.openbase.jul.exception.CouldNotPerformException;
 import org.openbase.jul.exception.FatalImplementationErrorException;
@@ -409,7 +410,7 @@ public class AbstractControllerServerTest extends MqttIntegrationTest {
         final String scope = "/test/parallel";
 
         // create and activate controller
-        communicationService = new AbstractControllerServerImpl(UnitRegistryData.getDefaultInstance().toBuilder());
+        communicationService = new AbstractControllerServerImpl(UnitRegistryData.newBuilder());
         communicationService.init(scope);
         communicationService.activate();
 
@@ -431,13 +432,7 @@ public class AbstractControllerServerTest extends MqttIntegrationTest {
             remoteService.ping().get();
 
             // verify that the data request is really blocked
-            TimeoutException timeoutException = null;
-            try {
-                dataFuture.get(500, TimeUnit.MILLISECONDS);
-            } catch (TimeoutException ex) {
-                timeoutException = ex;
-            }
-            assertNotNull(timeoutException, "Request data could be called even though the test thread holds the data lock!");
+            assertThrows(TimeoutException.class, () -> dataFuture.get(500, TimeUnit.MILLISECONDS));
         }
     }
 

--- a/module/communication/mqtt/build.gradle.kts
+++ b/module/communication/mqtt/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
     api(project(":jul.schedule"))
     api(project(":jul.extension.type.processing"))
     api("com.hivemq:hivemq-mqtt-client:_")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:_")
     testImplementation("org.testcontainers:junit-jupiter:_")  {
         exclude(group = "junit", module = "junit")
     }

--- a/module/communication/mqtt/src/main/java/org/openbase/jul/communication/mqtt/RPCServerImpl.kt
+++ b/module/communication/mqtt/src/main/java/org/openbase/jul/communication/mqtt/RPCServerImpl.kt
@@ -33,7 +33,11 @@ class RPCServerImpl(
     dispatcher: CoroutineDispatcher? = GlobalCachedExecutorService.getInstance().executorService.asCoroutineDispatcher()
 ) : RPCCommunicatorImpl(scope, config), RPCServer {
 
-    private val RPC_TIMEOUT = Duration.ofMinutes(3)
+    companion object {
+        val NO_DISPATCHER: CoroutineDispatcher? = null
+        val RPC_TIMEOUT: Duration = Duration.ofMinutes(3)
+    }
+
     private val logger: Logger = LoggerFactory.getLogger(RPCServerImpl::class.simpleName)
 
     private val methods: HashMap<String, RPCMethod> = HashMap()

--- a/module/communication/mqtt/src/main/java/org/openbase/jul/communication/mqtt/RPCServerImpl.kt
+++ b/module/communication/mqtt/src/main/java/org/openbase/jul/communication/mqtt/RPCServerImpl.kt
@@ -2,11 +2,10 @@ package org.openbase.jul.communication.mqtt
 
 import com.hivemq.client.internal.util.AsyncRuntimeException
 import com.hivemq.client.mqtt.datatypes.MqttQos
-import com.hivemq.client.mqtt.mqtt5.datatypes.Mqtt5UserPropertiesBuilder
-import com.hivemq.client.mqtt.mqtt5.datatypes.Mqtt5UserPropertiesBuilderBase
 import com.hivemq.client.mqtt.mqtt5.message.publish.Mqtt5Publish
 import com.hivemq.client.mqtt.mqtt5.message.subscribe.Mqtt5Subscribe
 import com.hivemq.client.mqtt.mqtt5.message.unsubscribe.Mqtt5Unsubscribe
+import kotlinx.coroutines.*
 import org.openbase.jul.communication.config.CommunicatorConfig
 import org.openbase.jul.communication.iface.RPCServer
 import org.openbase.jul.exception.CouldNotPerformException
@@ -21,14 +20,17 @@ import org.openbase.type.communication.mqtt.ResponseType
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.lang.reflect.InvocationTargetException
-import java.time.Instant
 import java.util.*
 import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 import kotlin.reflect.KFunction
 
-class RPCServerImpl(scope: Scope, config: CommunicatorConfig) : RPCCommunicatorImpl(scope, config), RPCServer {
+class RPCServerImpl(
+    scope: Scope,
+    config: CommunicatorConfig,
+    dispatcher: CoroutineDispatcher? = GlobalCachedExecutorService.getInstance().executorService.asCoroutineDispatcher()
+) : RPCCommunicatorImpl(scope, config), RPCServer {
 
     private val logger: Logger = LoggerFactory.getLogger(RPCServerImpl::class.simpleName)
 
@@ -36,6 +38,8 @@ class RPCServerImpl(scope: Scope, config: CommunicatorConfig) : RPCCommunicatorI
     private var activationFuture: Future<out Any>? = null
 
     private val lock = SyncObject("Activation Lock")
+
+    private val coroutineScope = if (dispatcher != null) CoroutineScope(dispatcher) else null
 
     internal fun getActivationFuture(): Future<out Any>? {
         return this.activationFuture
@@ -62,7 +66,13 @@ class RPCServerImpl(scope: Scope, config: CommunicatorConfig) : RPCCommunicatorI
                     // Note: this is a wrapper for the usage of a shared client
                     //       which may remain subscribed even if deactivate is called
                     if (isActive) {
-                        handleRemoteCall(mqtt5Publish)
+                        if (coroutineScope != null) {
+                            coroutineScope.launch {
+                                handleRemoteCall(mqtt5Publish)
+                            }
+                        } else {
+                            handleRemoteCall(mqtt5Publish)
+                        }
                     }
                 },
                 GlobalCachedExecutorService.getInstance().executorService
@@ -92,6 +102,7 @@ class RPCServerImpl(scope: Scope, config: CommunicatorConfig) : RPCCommunicatorI
                     .build()
             )
         }
+        coroutineScope?.cancel()
     }
 
     override fun registerMethod(method: KFunction<*>, instance: Any) {
@@ -143,7 +154,8 @@ class RPCServerImpl(scope: Scope, config: CommunicatorConfig) : RPCCommunicatorI
         } catch (ex: Exception) {
             when (ex) {
                 is InvocationTargetException -> responseBuilder.error =
-                    ex.cause?.stackTraceToString()?:ex.stackTraceToString()
+                    ex.cause?.stackTraceToString() ?: ex.stackTraceToString()
+
                 else -> {
                     ExceptionPrinter.printHistory(ex, logger, LogLevel.WARN)
                     responseBuilder.error = CouldNotPerformException("Server error ${ex.message}").stackTraceToString()

--- a/module/communication/mqtt/src/main/java/org/openbase/jul/communication/mqtt/RPCServerImpl.kt
+++ b/module/communication/mqtt/src/main/java/org/openbase/jul/communication/mqtt/RPCServerImpl.kt
@@ -32,6 +32,7 @@ class RPCServerImpl(
     dispatcher: CoroutineDispatcher? = GlobalCachedExecutorService.getInstance().executorService.asCoroutineDispatcher()
 ) : RPCCommunicatorImpl(scope, config), RPCServer {
 
+    //private val RPC_TIMEOUT = TimeUnit.SECONDS.convert(30, TimeUnit.MILLISECONDS)
     private val logger: Logger = LoggerFactory.getLogger(RPCServerImpl::class.simpleName)
 
     private val methods: HashMap<String, RPCMethod> = HashMap()
@@ -66,13 +67,11 @@ class RPCServerImpl(
                     // Note: this is a wrapper for the usage of a shared client
                     //       which may remain subscribed even if deactivate is called
                     if (isActive) {
-                        if (coroutineScope != null) {
-                            coroutineScope.launch {
-                                handleRemoteCall(mqtt5Publish)
-                            }
-                        } else {
+                        coroutineScope?.launch {
+                            //withTimeout(RPC_TIMEOUT) {
                             handleRemoteCall(mqtt5Publish)
-                        }
+                            //}
+                        } ?: handleRemoteCall(mqtt5Publish)
                     }
                 },
                 GlobalCachedExecutorService.getInstance().executorService

--- a/module/communication/mqtt/src/main/java/org/openbase/jul/communication/mqtt/RPCServerImpl.kt
+++ b/module/communication/mqtt/src/main/java/org/openbase/jul/communication/mqtt/RPCServerImpl.kt
@@ -20,6 +20,7 @@ import org.openbase.type.communication.mqtt.ResponseType
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.lang.reflect.InvocationTargetException
+import java.time.Duration
 import java.util.*
 import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
@@ -32,7 +33,7 @@ class RPCServerImpl(
     dispatcher: CoroutineDispatcher? = GlobalCachedExecutorService.getInstance().executorService.asCoroutineDispatcher()
 ) : RPCCommunicatorImpl(scope, config), RPCServer {
 
-    //private val RPC_TIMEOUT = TimeUnit.SECONDS.convert(30, TimeUnit.MILLISECONDS)
+    private val RPC_TIMEOUT = Duration.ofMinutes(3)
     private val logger: Logger = LoggerFactory.getLogger(RPCServerImpl::class.simpleName)
 
     private val methods: HashMap<String, RPCMethod> = HashMap()
@@ -68,9 +69,9 @@ class RPCServerImpl(
                     //       which may remain subscribed even if deactivate is called
                     if (isActive) {
                         coroutineScope?.launch {
-                            //withTimeout(RPC_TIMEOUT) {
-                            handleRemoteCall(mqtt5Publish)
-                            //}
+                            withTimeout(RPC_TIMEOUT.toMillis()) {
+                                handleRemoteCall(mqtt5Publish)
+                            }
                         } ?: handleRemoteCall(mqtt5Publish)
                     }
                 },

--- a/module/communication/mqtt/src/test/java/org/openbase/jul/communication/mqtt/IntegrationTest.kt
+++ b/module/communication/mqtt/src/test/java/org/openbase/jul/communication/mqtt/IntegrationTest.kt
@@ -33,9 +33,7 @@ class IntegrationTest : AbstractIntegrationTest() {
             throw CouldNotPerformException(errorMessage)
         }
 
-        fun ping(time: Long): Long {
-            return time
-        }
+        fun ping(time: Long) = time
 
         val lock = ReentrantLock()
         fun blockingRPC(msg: String): String {

--- a/module/communication/mqtt/src/test/java/org/openbase/jul/communication/mqtt/IntegrationTest.kt
+++ b/module/communication/mqtt/src/test/java/org/openbase/jul/communication/mqtt/IntegrationTest.kt
@@ -148,7 +148,7 @@ class IntegrationTest : AbstractIntegrationTest() {
             val time = 42L
             try {
                 val pingResult =
-                    rpcClient.callMethod(instance::ping.name, Long::class, time).get(100, TimeUnit.MILLISECONDS)
+                    rpcClient.callMethod(instance::ping.name, Long::class, time).get(100, TimeUnit.MILLISECONDS).response
                 pingResult shouldBe time
             } catch (ex: TimeoutException) {
                 fail("Could not ping while another RPCMethod is blocking!", ex)
@@ -156,10 +156,12 @@ class IntegrationTest : AbstractIntegrationTest() {
             blockingFuture.isDone shouldBe false
 
             instance.lock.unlock()
-            val blockingResult = blockingFuture.get(100, TimeUnit.MILLISECONDS)
+            val blockingResult = blockingFuture.get(100, TimeUnit.MILLISECONDS).response
             blockingResult shouldBe expectedMsg
         } finally {
-            instance.lock.unlock()
+            if (instance.lock.isLocked) {
+                instance.lock.unlock()
+            }
         }
     }
 }

--- a/module/communication/mqtt/src/test/java/org/openbase/jul/communication/mqtt/RPCServerImplTest.kt
+++ b/module/communication/mqtt/src/test/java/org/openbase/jul/communication/mqtt/RPCServerImplTest.kt
@@ -4,7 +4,6 @@ import com.hivemq.client.mqtt.datatypes.MqttQos
 import com.hivemq.client.mqtt.mqtt5.Mqtt5AsyncClient
 import com.hivemq.client.mqtt.mqtt5.message.publish.Mqtt5Publish
 import com.hivemq.client.mqtt.mqtt5.message.subscribe.Mqtt5Subscribe
-import com.hivemq.client.mqtt.mqtt5.message.subscribe.suback.Mqtt5SubAck
 import com.hivemq.client.mqtt.mqtt5.message.unsubscribe.Mqtt5Unsubscribe
 import io.kotest.matchers.ints.shouldBeGreaterThan
 import io.kotest.matchers.shouldBe
@@ -22,7 +21,6 @@ import org.openbase.jul.extension.type.processing.ScopeProcessor
 import org.openbase.jul.schedule.GlobalCachedExecutorService
 import org.openbase.type.communication.mqtt.RequestType.Request
 import org.openbase.type.communication.mqtt.ResponseType.Response
-import java.lang.reflect.InvocationTargetException
 import java.util.concurrent.CompletableFuture
 import java.util.function.Consumer
 
@@ -50,7 +48,11 @@ internal class RPCServerImplTest {
         mockkObject(SharedMqttClient)
         every { SharedMqttClient.get(any()) } returns mqttClient
 
-        rpcServer = RPCServerImpl(ScopeProcessor.generateScope(baseTopic), CommunicatorConfig("localhost", 1234), dispatcher = null)
+        rpcServer = RPCServerImpl(
+            ScopeProcessor.generateScope(baseTopic),
+            CommunicatorConfig("localhost", 1234),
+            RPCServerImpl.NO_DISPATCHER
+        )
     }
 
     @AfterAll

--- a/module/communication/mqtt/src/test/java/org/openbase/jul/communication/mqtt/RPCServerImplTest.kt
+++ b/module/communication/mqtt/src/test/java/org/openbase/jul/communication/mqtt/RPCServerImplTest.kt
@@ -50,7 +50,7 @@ internal class RPCServerImplTest {
         mockkObject(SharedMqttClient)
         every { SharedMqttClient.get(any()) } returns mqttClient
 
-        rpcServer = RPCServerImpl(ScopeProcessor.generateScope(baseTopic), CommunicatorConfig("localhost", 1234))
+        rpcServer = RPCServerImpl(ScopeProcessor.generateScope(baseTopic), CommunicatorConfig("localhost", 1234), dispatcher = null)
     }
 
     @AfterAll

--- a/versions.properties
+++ b/versions.properties
@@ -85,6 +85,8 @@ plugin.org.gradle.kotlin.kotlin-dsl=2.3.3
 
 plugin.io.github.gradle-nexus.publish-plugin=1.1.0
 
+version.kotlinx.coroutines=1.6.4
+
 ## unused
 version.rxjava2.rxjava=2.2.21
 


### PR DESCRIPTION
### :scroll: Description

Changes proposed in this pull request:
* Make RPC calls parallel by submitting method calls as coroutines on the GlobalCachedExecutorService

### :white_check_mark: Checklist:

- [x] Created tests which fail without the change (if possible)
