### PR TITLE
Reduce deadlock potential in FileSynchronizedRegistryImpl and Audio Engine improvements

### DIFF
--- a/module/audio/src/main/java/org/openbase/jul/audio/AudioPlayer.kt
+++ b/module/audio/src/main/java/org/openbase/jul/audio/AudioPlayer.kt
@@ -20,7 +20,13 @@ import kotlin.concurrent.withLock
  * @author [Divine Threepwood](mailto:divine@openbase.org)
  */
 class AudioPlayer @JvmOverloads constructor(soundChannels: Int = 10) {
-    private val executorService: ExecutorService = Executors.newFixedThreadPool(soundChannels)
+    private val executorService: ExecutorService = Executors.newFixedThreadPool(soundChannels) { runnable: Runnable ->
+        Executors.defaultThreadFactory().newThread(runnable)
+            .apply {
+                isDaemon = true
+                priority = 9
+            }
+    }
 
     @JvmOverloads
     fun playAudio(source: AudioSource, wait: Boolean = false): Boolean {

--- a/module/audio/src/main/java/org/openbase/jul/audio/AudioPlayer.kt
+++ b/module/audio/src/main/java/org/openbase/jul/audio/AudioPlayer.kt
@@ -24,7 +24,7 @@ class AudioPlayer @JvmOverloads constructor(soundChannels: Int = 10) {
         Executors.defaultThreadFactory().newThread(runnable)
             .apply {
                 isDaemon = true
-                priority = 9
+                priority = Thread.MAX_PRIORITY.dec()
             }
     }
 


### PR DESCRIPTION
### :scroll: Description

Changes proposed in this pull request:
* Reduce deadlock potential in FileSynchronizedRegistryImpl by making sure the lock is not hold once external methods are called.
* Make sure the Audio Engine only uses high priority threads to play audio. This will reduce sound artifacts during playback.