### PR TITLE
Fix setup-gradle argument deprication

### DIFF
--- a/.github/workflows/publish-jars.yml
+++ b/.github/workflows/publish-jars.yml
@@ -25,10 +25,20 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@v6
         
-      - name: Publish Packages
+      - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
-        with:
-          arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+
+      - name: publishToSonatype
+        run: ./gradlew publishToSonatype
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORG_GRADLE_PROJECT_OPENBASE_GPG_PRIVATE_KEY: ${{ secrets.OPENBASE_GPG_PRIVATE_KEY }}
+          ORG_GRADLE_PROJECT_OPENBASE_GPG_PRIVATE_KEY_PASSPHRASE: ""
+          ORG_GRADLE_PROJECT_MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
+
+      - name: closeAndReleaseSonatypeStagingRepository
+        run: ./gradlew closeAndReleaseSonatypeStagingRepository
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ORG_GRADLE_PROJECT_OPENBASE_GPG_PRIVATE_KEY: ${{ secrets.OPENBASE_GPG_PRIVATE_KEY }}


### PR DESCRIPTION
### :scroll: Description

Changes proposed in this pull request:

- Starting with v4, setup-gradle did not support arguments anymore.
https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#the-action-gradlegradle-build-action-has-been-replaced-by-gradleactionssetup-gradle
